### PR TITLE
Set ecr region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+#IntelliJ
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -100,5 +100,5 @@ ENV/
 # mypy
 .mypy_cache/
 
-#IntelliJ
+# IntelliJ
 .idea

--- a/pybuilder-docker.iml
+++ b/pybuilder-docker.iml
@@ -2,13 +2,8 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/src/main/python" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/unittest/python" isTestSource="true" />
-    </content>
+    <content url="file://$MODULE_DIR$" />
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="R User Library" level="project" />
-    <orderEntry type="library" name="R Skeletons" level="application" />
   </component>
 </module>


### PR DESCRIPTION
Added option project property `docker_set_ecr_region`

This is necessary for an edge case that we've run into for cross account ECR access. When the calling AWS account role has a different default AWS region than the parent containing the ECR repository, it's necessary to make the call with the `--region <region>` option in order for authentication to succeed. 
