### PR TITLE
Update get_dist_file_name to search by underscores

### DIFF
--- a/src/main/python/pybuilder_docker_too/__init__.py
+++ b/src/main/python/pybuilder_docker_too/__init__.py
@@ -442,7 +442,7 @@ def _get_docker_compose_file(project):
 
 
 def get_dist_file_name(project):
-    default_dist_file = "{name}-{version}.tar.gz".format(name=project.name, version=project.version)
+    default_dist_file = f"{project.name}-{project.version}.tar.gz".replace('-', '_')
     return project.get_property("docker_package_dist_file", default_dist_file)
 
 


### PR DESCRIPTION
Pybuilder latest release changes the way the dist file is generated and now it uses underscores 